### PR TITLE
Cisco FTD documention update for Acl_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An [Ansible](https://ansible.com) role to manage access control lists for many f
 
 Current supported list of providers:
 * checkpoint
+* Cisco FTD
 
 Requirements
 ------------
@@ -16,10 +17,15 @@ Scientific Linux 7, etc
 Functions
 ---------
 
-* `blacklist_ip` - This blacklist a source IP  address from accessing a destination IP address
+* `blacklist_ip` - This blacklist a source IP address from accessing a destination IP address.
+* `whitelist_ip` - This whitelist a Network address or Host address.
+* `blacklist_url` - This blacklist a URL feed/address from being accessed.
+* `whitelist_url` - This whitelist a URL feed/address, which in turn can be accessed without being blocked.
 
 Example Playbook
 ----------------
+
+* `Checkpoint blacklist IP address`
 
 ```
 - hosts: checkpoint
@@ -33,6 +39,78 @@ Example Playbook
         source_ip: 192.168.0.10
         destination_ip: 192.168.0.11
         firewall_provider: checkpoint
+```
+
+* `Cisco FTD whitelist Network address`
+
+```
+- hosts: ftd
+  connection: httpapi
+
+  tasks:
+    - include_role:
+        name: acl_manager
+        tasks_from: whitelist_ip
+      vars:
+        whitelist_network_type: network
+        whitelist_name: permit_network
+        whitelist_subtype: NETWORK
+        whitelist_value: 192.168.1.0/24
+        firewall_provider: cisco_ftd
+```
+
+* `Cisco FTD blacklist Network address`
+
+```
+- hosts: ftd
+  connection: httpapi
+
+  tasks:
+    - include_role:
+        name: acl_manager
+        tasks_from: blacklist_ip
+      vars:
+        blacklist_network_type: network
+        blacklist_name: block_network
+        blacklist_subtype: NETWORK
+        blacklist_value: 192.168.2.0/24
+        firewall_provider: cisco_ftd
+```
+
+* `Cisco FTD whitelist URL address`
+
+```
+- hosts: checkpoint
+  connection: httpapi
+
+  tasks:
+    - include_role:
+        name: acl_manager
+        tasks_from: whitelist_url
+      vars:
+        whitelist_url_type: url
+        whitelist_name: GoogleURL
+        whitelist_url_description: URL for Google
+        whitelist_url: www.google.com
+        firewall_provider: cisco_ftd
+```
+
+* `Cisco FTD blacklist URL address`
+
+```
+- hosts: ftd
+  connection: httpapi
+
+  tasks:
+    - include_role:
+        name: acl_manager
+        tasks_from: blacklist_url
+      vars:
+        blacklist_url_type: url
+        blacklist_name: Attacker_Url
+        blacklist_url_description: Detected Attacker URL
+        blacklist_url: www.attacker.com
+        firewall_provider: cisco_ftd
 ```
 
 


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

Updated the acl_manger `Readme` doc with Cisco FTD supported feature and relevant examples